### PR TITLE
Add strong tag for no search results within the search function

### DIFF
--- a/core/src/views/UnifiedSearch.vue
+++ b/core/src/views/UnifiedSearch.vue
@@ -76,7 +76,7 @@
 			<SearchResultPlaceholders v-if="isLoading" />
 
 			<EmptyContent v-else-if="isValidQuery" icon="icon-search">
-				{{ t('core', 'No results for {query}', {query}) }}
+				{{ t('core', 'No results for') }} <strong>{{ t('query', query) }}</strong>
 			</EmptyContent>
 
 			<EmptyContent v-else-if="!isLoading || isShortQuery" icon="icon-search">


### PR DESCRIPTION
NMCLOUD-464 : We applied a strong tag for user input on the "no results" screen within the search function.