### PR TITLE
Nmc 430 - harmonizing sharing permissions step #1

### DIFF
--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -45,53 +45,24 @@
 			@close="onMenuClose">
 			<template v-if="share.canEdit">
 				<!-- folder -->
-				<template v-if="isFolder && fileHasCreatePermission && config.isPublicUploadEnabled">
-					<template v-if="isRemoteShare">
-						<!-- edit permission -->
-						<ActionCheckbox
-							ref="canEdit"
-							:checked.sync="canEdit"
-							:value="permissionsEdit"
-							:disabled="saving || !canSetEdit">
-							{{ t('files_sharing', 'Allow editing') }}
-						</ActionCheckbox>
+				<template v-if="isFolder && config.isPublicUploadEnabled">
 
-						<!-- create permission -->
-						<ActionCheckbox
-							ref="canCreate"
-							:checked.sync="canCreate"
-							:value="permissionsCreate"
-							:disabled="saving || !canSetCreate">
-							{{ t('files_sharing', 'Allow creating') }}
-						</ActionCheckbox>
+					<ActionRadio :checked="sharePermissions === publicUploadRValue"
+						:value="publicUploadRValue"
+						:name="randomId"
+						:disabled="saving"
+						@change="togglePermissions">
+						{{ t('files_sharing', 'Read only') }}
+					</ActionRadio>
 
-						<!-- delete permission -->
-						<ActionCheckbox
-							ref="canDelete"
-							:checked.sync="canDelete"
-							:value="permissionsDelete"
-							:disabled="saving || !canSetDelete">
-							{{ t('files_sharing', 'Allow deleting') }}
-						</ActionCheckbox>
-					</template>
-					<template v-else>
-						<ActionRadio :checked="sharePermissions === publicUploadRValue"
-							:value="publicUploadRValue"
-							:name="randomId"
-							:disabled="saving"
-							@change="togglePermissions">
-							{{ t('files_sharing', 'Read only') }}
-						</ActionRadio>
+					<ActionRadio :checked="sharePermissions === publicUploadRWValue"
+						:value="publicUploadRWValue"
+						:disabled="saving"
+						:name="randomId"
+						@change="togglePermissions">
+						{{ t('files_sharing', 'Allow upload and editing') }}
+					</ActionRadio>
 
-						<ActionRadio :checked="sharePermissions === publicUploadRWValue"
-							:value="publicUploadRWValue"
-							:disabled="saving"
-							:name="randomId"
-							@change="togglePermissions">
-							{{ t('files_sharing', 'Allow upload and editing') }}
-						</ActionRadio>
-
-					</template>
 				</template>
 				<!-- file -->
 				<template v-else>

--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -44,34 +44,73 @@
 			class="sharing-entry__actions"
 			@close="onMenuClose">
 			<template v-if="share.canEdit">
-				<!-- edit permission -->
-				<ActionCheckbox
-					ref="canEdit"
-					:checked.sync="canEdit"
-					:value="permissionsEdit"
-					:disabled="saving || !canSetEdit">
-					{{ t('files_sharing', 'Allow editing') }}
-				</ActionCheckbox>
+				<!-- folder -->
+				<template v-if="isFolder && fileHasCreatePermission && config.isPublicUploadEnabled">
+					<template v-if="isRemoteShare">
+						<!-- edit permission -->
+						<ActionCheckbox
+							ref="canEdit"
+							:checked.sync="canEdit"
+							:value="permissionsEdit"
+							:disabled="saving || !canSetEdit">
+							{{ t('files_sharing', 'Allow editing') }}
+						</ActionCheckbox>
 
-				<!-- create permission -->
-				<ActionCheckbox
-					v-if="isFolder"
-					ref="canCreate"
-					:checked.sync="canCreate"
-					:value="permissionsCreate"
-					:disabled="saving || !canSetCreate">
-					{{ t('files_sharing', 'Allow creating') }}
-				</ActionCheckbox>
+						<!-- create permission -->
+						<ActionCheckbox
+							ref="canCreate"
+							:checked.sync="canCreate"
+							:value="permissionsCreate"
+							:disabled="saving || !canSetCreate">
+							{{ t('files_sharing', 'Allow creating') }}
+						</ActionCheckbox>
 
-				<!-- delete permission -->
-				<ActionCheckbox
-					v-if="isFolder"
-					ref="canDelete"
-					:checked.sync="canDelete"
-					:value="permissionsDelete"
-					:disabled="saving || !canSetDelete">
-					{{ t('files_sharing', 'Allow deleting') }}
-				</ActionCheckbox>
+						<!-- delete permission -->
+						<ActionCheckbox
+							ref="canDelete"
+							:checked.sync="canDelete"
+							:value="permissionsDelete"
+							:disabled="saving || !canSetDelete">
+							{{ t('files_sharing', 'Allow deleting') }}
+						</ActionCheckbox>
+					</template>
+					<template v-else>
+						<ActionRadio :checked="sharePermissions === publicUploadRValue"
+							:value="publicUploadRValue"
+							:name="randomId"
+							:disabled="saving"
+							@change="togglePermissions">
+							{{ t('files_sharing', 'Read only') }}
+						</ActionRadio>
+
+						<ActionRadio :checked="sharePermissions === publicUploadRWValue"
+							:value="publicUploadRWValue"
+							:disabled="saving"
+							:name="randomId"
+							@change="togglePermissions">
+							{{ t('files_sharing', 'Allow upload and editing') }}
+						</ActionRadio>
+
+					</template>
+				</template>
+				<!-- file -->
+				<template v-else>
+					<ActionRadio :checked="sharePermissions === publicUploadRValue"
+						:value="publicUploadRValue"
+						:name="randomId"
+						:disabled="saving"
+						@change="togglePermissions">
+						{{ t('files_sharing', 'Read only') }}
+					</ActionRadio>
+
+					<ActionRadio :checked="sharePermissions === publicUploadEValue"
+						:value="publicUploadEValue"
+						:disabled="saving"
+						:name="randomId"
+						@change="togglePermissions">
+						{{ t('files_sharing', 'Editing') }}
+					</ActionRadio>
+				</template>
 
 				<!-- reshare permission -->
 				<ActionCheckbox
@@ -84,7 +123,9 @@
 				</ActionCheckbox>
 
 				<!-- expiration date -->
-				<ActionCheckbox :checked.sync="hasExpirationDate"
+				<ActionCheckbox
+					v-if="canHaveExpirationDate"
+					:checked.sync="hasExpirationDate"
 					:disabled="config.isDefaultInternalExpireDateEnforced || saving"
 					@uncheck="onExpirationDisable">
 					{{ config.isDefaultInternalExpireDateEnforced
@@ -149,6 +190,7 @@
 import Avatar from '@nextcloud/vue/dist/Components/Avatar'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
+import ActionRadio from '@nextcloud/vue/dist/Components/ActionRadio'
 import ActionCheckbox from '@nextcloud/vue/dist/Components/ActionCheckbox'
 import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
 import ActionTextEditable from '@nextcloud/vue/dist/Components/ActionTextEditable'
@@ -162,6 +204,7 @@ export default {
 	components: {
 		Actions,
 		ActionButton,
+		ActionRadio,
 		ActionCheckbox,
 		ActionInput,
 		ActionTextEditable,
@@ -181,10 +224,34 @@ export default {
 			permissionsDelete: OC.PERMISSION_DELETE,
 			permissionsRead: OC.PERMISSION_READ,
 			permissionsShare: OC.PERMISSION_SHARE,
+
+			publicUploadRWValue: OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE,
+			publicUploadRValue: OC.PERMISSION_READ,
+			publicUploadWValue: OC.PERMISSION_CREATE | OC.PERMISSION_READ,
+			publicUploadEValue: OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
 		}
 	},
 
 	computed: {
+		/**
+		 * Return the current share permissions
+		 * We always ignore the SHARE permission as this is used for the
+		 * federated sharing.
+		 * @returns {number}
+		 */
+		sharePermissions() {
+			return this.share.permissions & ~OC.PERMISSION_SHARE
+		},
+		/**
+		 * Generate a unique random id for this SharingEntryLink only
+		 * This allows ActionRadios to have the same name prop
+		 * but not to impact others SharingEntryLink
+		 * @returns {string}
+		 */
+		randomId() {
+			return Math.random().toString(27).substr(2)
+		},
+
 		title() {
 			let title = this.share.shareWithDisplayName
 			if (this.share.type === this.SHARE_TYPES.SHARE_TYPE_GROUP) {
@@ -394,6 +461,17 @@ export default {
 				| (isEditChecked ? this.permissionsEdit : 0)
 				| (isReshareChecked ? this.permissionsShare : 0)
 
+			this.share.permissions = permissions
+			this.queueUpdate('permissions')
+		},
+
+		/**
+		 * On permissions change
+		 * @param {Event} event js event
+		 */
+		togglePermissions(event) {
+			const permissions = parseInt(event.target.value, 10)
+			| (this.canReshare ? this.permissionsShare : 0)
 			this.share.permissions = permissions
 			this.queueUpdate('permissions')
 		},

--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -178,12 +178,23 @@
 					</template>
 
 					<!-- file -->
-					<ActionCheckbox v-else
-						:checked.sync="canUpdate"
-						:disabled="saving"
-						@change="queueUpdate('permissions')">
-						{{ t('files_sharing', 'Allow editing') }}
-					</ActionCheckbox>
+					<template v-else>
+						<ActionRadio :checked="sharePermissions === publicUploadRValue"
+							:value="publicUploadRValue"
+							:name="randomId"
+							:disabled="saving"
+							@change="togglePermissions">
+							{{ t('files_sharing', 'Read only') }}
+						</ActionRadio>
+
+						<ActionRadio :checked="sharePermissions === publicUploadEValue"
+							:value="publicUploadEValue"
+							:disabled="saving"
+							:name="randomId"
+							@change="togglePermissions">
+							{{ t('files_sharing', 'Editing') }}
+						</ActionRadio>
+					</template>
 
 					<ActionCheckbox
 						:checked.sync="share.hideDownload"
@@ -380,6 +391,7 @@ export default {
 			publicUploadRWValue: OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_READ | OC.PERMISSION_DELETE,
 			publicUploadRValue: OC.PERMISSION_READ,
 			publicUploadWValue: OC.PERMISSION_CREATE,
+			publicUploadEValue: OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
 
 			ExternalLinkActions: OCA.Sharing.ExternalLinkActions.state,
 		}


### PR DESCRIPTION
Changes did as below for step #1 to harmonize sharing permissions
For folders
Internal Share
we removed the checkboxes "Allow editing", "Allow creating" and "Allow deleting"
we added a radio button group containing the options: "Read only" (Nur Lesen), "Allow upload and editing" (Hochladen & Bearbeiten)
External Share: no changes
Link Share: no changes
For files
Internal Share
we removed the checkbox "Allow editing"
we added a radio button group containing the options: "Read only" (Nur lesen), "Editing" (Bearbeiten)
External Share
we removed the checkbox "Allow editing"
we added a radio button group containing the options: "Read only" (Nur lesen), "Editing" (Bearbeiten)
Link Share
we removed the checkbox "Allow editing"
we added a radio button group containing the options: "Read only" (Nur lesen), "Editing" (Bearbeiten)