### PR TITLE
127-file multiselection action

### DIFF
--- a/apps/files/css/files.scss
+++ b/apps/files/css/files.scss
@@ -253,6 +253,7 @@ table th .columntitle.name {
 
 table.multiselect th .columntitle.name {
 	margin-left: 0;
+	padding-left: 15px;
 }
 
 table th .sort-indicator {
@@ -340,7 +341,7 @@ table.multiselect thead th {
 
 table.multiselect .column-name {
 	position: relative;
-	width: 9999px; /* when we use 100%, the styling breaks on mobile … table styling */
+	width: auto;
 }
 table.multiselect .column-mtime>a {
 	display: none;
@@ -1322,4 +1323,113 @@ table.dragshadow td.size {
 		min-width: 0;
 		margin: 0 12px;
 	}
+}
+
+/* Actions for selected files */
+#headerSize .hidden	{
+	display: none;
+}
+
+#headerDate .hidden {
+	display: none;
+}
+
+#headerSizeOpen .hidden {
+	display: none;
+}
+
+table.multiselect {
+	thead {
+		#selectedMenu {
+			width: 100%;
+		}
+	}
+}
+
+.multiselect {
+	.sort-indicator {
+		display: none !important;
+	}
+}
+
+#selectedActionLabel {
+	padding-right: 16px;
+	display: none;
+	a {
+		display: inline;
+		line-height: 50px;
+		padding: 16px 5px;
+		img {
+			position: relative;
+			vertical-align: text-bottom;
+			margin-bottom: -1px;
+		}
+	}
+	a.hidden {
+		display: none;
+	}
+	.actions-selected {
+		.icon-more {
+			display: inline-block;
+			vertical-align: middle;
+		}
+	}
+}
+
+#headerSizeCount .hidden {
+	display: none !important;
+}
+
+.selectedActions {
+	.filesSelectionMenu {
+		display: block !important;
+		ul {
+			li {
+				display: inline;
+				&.hidden {
+					display: none !important;
+				}
+			}
+		}
+		a {
+			.label {
+					padding-left: 8px;
+					padding-right: 19px;
+			}
+			&:hover {
+				.label {
+					text-decoration: underline;
+				}
+			}
+		}
+	}
+}
+
+#selectedActionsList {
+	width: 100% !important;
+	text-align: right !important;
+	opacity: unset;
+	.popovermenu {
+		right: -70px;
+		top: 45px;
+	}
+}
+
+#allLabel {
+	padding-top: 5px;
+}
+
+.item-cancel {
+	a {
+		.label {
+			color: #ff0000;
+		}
+	}
+	.icon-close {
+		filter: invert(18%) sepia(99%) saturate(7440%) hue-rotate(1deg) brightness(110%) contrast(115%);
+	}
+}
+
+.hidden-action{
+	display: none !important;
 }

--- a/apps/files/css/mobile.scss
+++ b/apps/files/css/mobile.scss
@@ -82,4 +82,37 @@ table.dragshadow {
 	table.multiselect th .columntitle.name {
 		margin-left: 0;
 	}
+
+	/* Actions for selected files */
+	table th #selectedActionLabel a {
+		padding: 17px 14px;
+	}
+
+	#allLabel {
+		display: none;
+	}
+
+	#selectedActionsList .filesSelectionMenu {
+		display: none !important;
+	}
+
+	#selectedActionsList .popovermenu {
+		right: -70px;
+		top: 25px;
+	}
+
+	#selectedActionLabel {
+		padding-right: 0px;
+	}
+
+	table th .columntitle.name {
+		margin-left: 0;
+	}
+}
+
+@media only screen and (max-width: 440px) {
+	#selectedActionsList .popovermenu {
+		right: -85px;
+		top: 20px;
+	}
 }

--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -114,6 +114,12 @@
 							iconClass: 'icon-tag',
 							order: 100,
 						},
+						{
+							name: 'cancel',
+							displayName: t('files', 'Cancel'),
+							iconClass: 'icon-close',
+							order: 101,
+						},
 					],
 					sorting: {
 						mode: $('#defaultFileSorting').val() === 'basename'

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -683,6 +683,7 @@
 		 * @param {boolean} [show=true] whether to open the sidebar if it was closed
 		 */
 		_updateDetailsView: function(fileName, show) {
+			this.resizeFileActionMenu();
 			if (!(OCA.Files && OCA.Files.Sidebar)) {
 				console.error('No sidebar available');
 				return;

--- a/apps/files/js/filemultipleselectionmenu.js
+++ b/apps/files/js/filemultipleselectionmenu.js
@@ -9,9 +9,9 @@
  */
 
 (function() {
-	var FileMultiSelectMenu = OC.Backbone.View.extend({
+	var FileMultipleSelectionMenu = OC.Backbone.View.extend({
 		tagName: 'div',
-		className: 'filesSelectMenu popovermenu bubble menu-right',
+		className: 'filesSelectionMenu',
 		_scopes: null,
 		initialize: function(menuItems) {
 			this._scopes = menuItems;
@@ -34,17 +34,16 @@
 		 * @param {OCA.Files.FileActionContext} context context
 		 * @param {Object} $trigger trigger element
 		 */
-		show: function(context) {
+		 show: function(context) {
 			this._context = context;
-			this.$el.removeClass('hidden');
-			OC.showMenu(null, this.$el);
 			return false;
 		},
 		toggleItemVisibility: function (itemName, show) {
+			var toggle= $('.filesSelectionMenu');
 			if (show) {
-				this.$el.find('.item-' + itemName).removeClass('hidden');
+				toggle.find('.item-' + itemName).removeClass('hidden-action');
 			} else {
-				this.$el.find('.item-' + itemName).addClass('hidden');
+				toggle.find('.item-' + itemName).addClass('hidden-action');
 			}
 		},
 		updateItemText: function (itemName, translation) {
@@ -88,6 +87,5 @@
 		}
 	});
 
-	OCA.Files.FileMultiSelectMenu = FileMultiSelectMenu;
+	OCA.Files.FileMultipleSelectionMenu = FileMultipleSelectionMenu;
 })(OC, OCA);
-

--- a/apps/files/js/merged-index.json
+++ b/apps/files/js/merged-index.json
@@ -12,6 +12,7 @@
   "fileinfomodel.js",
   "filelist.js",
   "filemultiselectmenu.js",
+  "filemultipleselectionmenu.js",
   "files.js",
   "filesummary.js",
   "gotoplugin.js",

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -32,39 +32,50 @@
 	<h2><?php p($l->t('No entries found in this folder')); ?></h2>
 	<p></p>
 </div>
-<table class="files-filestable list-container <?php p($_['showgridview'] ? 'view-grid' : '') ?>" data-allow-public-upload="<?php p($_['publicUploadEnabled'])?>" data-preview-x="250" data-preview-y="250">
+<table id="filestable" class="files-filestable list-container <?php p($_['showgridview'] ? 'view-grid' : '') ?>" data-allow-public-upload="<?php p($_['publicUploadEnabled'])?>" data-preview-x="250" data-preview-y="250">
 	<thead>
 		<tr>
-			<th class="hidden column-selection">
+			<th id="headerSelection" class="hidden column-selection">
 				<input type="checkbox" id="select_all_files" class="select-all checkbox"/>
 				<label for="select_all_files">
 					<span class="hidden-visually"><?php p($l->t('Select all'))?></span>
 				</label>
 			</th>
-			<th class="hidden column-name">
-				<div class="column-name-container">
-					<a class="name sort columntitle" onclick="event.preventDefault()" href="#" data-sort="name">
+			<th id='allLabel'><?php p($l->t('All')); ?></th>
+			<th id='headerName' class="hidden column-name">
+				<div id="headerName-container"  class="column-name-container">
+				<a class="name sort columntitle" onclick="event.preventDefault()" href="#" data-sort="name">
                         <span><?php p($l->t('Name')); ?></span>
-                        <span class="sort-indicator"></span>
-
-                    </a>
-                    <span class="selectedActions">
-                        <a href="#" onclick="event.preventDefault()" class="actions-selected">
-                            <span class="icon icon-more"></span>
-                            <span><?php p($l->t('Actions'))?></span>
-                        </a>
-					</span>
+						<span class="sort-indicator"></span>
+						<span class="headerSizeOpen">(</span>
+						<span id="headerSizeCount" class="column-size">
+							<?php p($l->t('Size')); ?>
+						</span>
+						<span class="headerSizeOpen">)</span>
+					</a>
 				</div>
 			</th>
-			<th class="hidden column-size">
+			<th  id="headerSize" class="hidden column-size">
 				<a class="size sort columntitle" href="#" onclick="event.preventDefault()" data-sort="size"><span><?php p($l->t('Size')); ?></span><span class="sort-indicator"></span></a>
 			</th>
-			<th class="hidden column-mtime">
+			<th id="headerDate" class="hidden column-mtime">
 				<a class="columntitle" href="#" onclick="event.preventDefault()" data-sort="mtime"><span><?php p($l->t('Modified')); ?></span><span class="sort-indicator"></span></a>
+			</th>
+			<th id="selectedMenu">
+				<div id="selectedActionsList" class="selectedActions">
+				</div>
+			</th>
+			<th>
+				<span id="selectedActionLabel">
+				<a href="#" onclick="event.preventDefault()" class="actions-selected">
+						<span class="icon icon-more"></span>
+						<span><?php  p($l->t('Actions'))?></span>
+					</a>
+				</span>
 			</th>
 		</tr>
 	</thead>
-	<tbody class="files-fileList">
+	<tbody id="fileList" class="files-fileList">
 	</tbody>
 	<tfoot>
 	</tfoot>

--- a/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
+++ b/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
@@ -228,6 +228,7 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 			Util::addScript('files', 'newfilemenu');
 			Util::addScript('files', 'files');
 			Util::addScript('files', 'filemultiselectmenu');
+			Util::addScript('files', 'filemultipleselectionmenu');
 			Util::addScript('files', 'filelist');
 			Util::addScript('files', 'keyboardshortcuts');
 			Util::addScript('files', 'operationprogressbar');


### PR DESCRIPTION
This PR contains the following changes:
**File action button behaviour changes:**

- We now show more single actions depending on the viewport size in the table header beginning from the first option in the dropdown.
- We add a new option called "Cancel" (ger: Abbrechen") which will remove any selection (just remove selection, not the files of course).
- We right align the Actions button.
- We will show every option in the action button dropdown. It doesnt matter which option is also shown in the table header.
- We add a new label called "All".
- on S: we hide the label "All" according to the screen design