### PR TITLE
Use email address as identifier for token in settings

### DIFF
--- a/apps/settings/lib/Controller/AuthSettingsController.php
+++ b/apps/settings/lib/Controller/AuthSettingsController.php
@@ -157,9 +157,10 @@ class AuthSettingsController extends Controller {
 
 		$this->publishActivity(Provider::APP_TOKEN_CREATED, $deviceToken->getId(), ['name' => $deviceToken->getName()]);
 
+		$user = $this->userSession->getUser();
 		return new JSONResponse([
 			'token' => $token,
-			'loginName' => $loginName,
+			'loginName' => $user->getEMailAddress(),
 			'deviceToken' => $tokenData,
 		]);
 	}


### PR DESCRIPTION
This PR contains the following changes:

Devices & Sessions page(Settings): Replace username with email address