### PR TITLE
[backport]Use email address as identifier for token - simple Test

### DIFF
--- a/apps/settings/lib/Controller/AuthSettingsController.php
+++ b/apps/settings/lib/Controller/AuthSettingsController.php
@@ -157,9 +157,10 @@ class AuthSettingsController extends Controller {
 
 		$this->publishActivity(Provider::APP_TOKEN_CREATED, $deviceToken->getId(), ['name' => $deviceToken->getName()]);
 
+		$user = $this->userSession->getUser(); // mark backport
 		return new JSONResponse([
 			'token' => $token,
-			'loginName' => $loginName,
+			'loginName' => $user->getEMailAddress(),
 			'deviceToken' => $tokenData,
 		]);
 	}


### PR DESCRIPTION
This is a test backport for debugging build process

Not that the backport is identified by its branch name, it has the same prefix as the master branch, but a version marker
suffix added: `nmc/731-settings-mail-address-username-25`

The base branch to merge to is a stable release branch forked from a Nextcloud version tag for enterprise version.

To be included it needs the usual marker labels "custom" and "build-ready".