### PR TITLE
[backport]File action button behaviour

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -373,6 +373,8 @@
 			$(window).resize(this._onResize);
 
 			this.$el.on('show', this._onResize);
+			this.resizeFileActionMenu = _.debounce(_.bind(this.resizeFileActionMenu, this), 250);
+			$(window).resize(this.resizeFileActionMenu);
 
 			// reload files list on share accept
 			$('body').on('OCA.Notification.Action', function(eventObject) {
@@ -675,6 +677,7 @@
 		 * @param {boolean} [show=true] whether to open the sidebar if it was closed
 		 */
 		_updateDetailsView: function(fileName, show) {
+			this.resizeFileActionMenu();
 			if (!(OCA.Files && OCA.Files.Sidebar)) {
 				console.error('No sidebar available');
 				return;
@@ -1502,6 +1505,12 @@
 			this.fileMultiSelectMenu.render();
 			this.$el.find('.selectedActions .filesSelectMenu').remove();
 			this.$el.find('.selectedActions').append(this.fileMultiSelectMenu.$el);
+			this.fileMultipleSelectionMenu = new OCA.Files.FileMultipleSelectionMenu(this.multiSelectMenuItems.sort(function(a, b) {
+				return a.order - b.order
+			}));
+			this.fileMultipleSelectionMenu.render();
+			this.$el.find('.selectedActions .filesSelectionMenu').remove();
+			this.$el.find('.selectedActions').append(this.fileMultipleSelectionMenu.$el);
 		},
 
 		/**
@@ -3496,6 +3505,72 @@
 					} else {
 						this.fileMultiSelectMenu.toggleItemVisibility('copyMove', false);
 					}
+				}
+			}
+		},
+
+			/**
+		 * Show or hide file action menu based on the current selection
+		*/
+		resizeFileActionMenu: function() {
+			const appList = this.$el.find('.filesSelectionMenu ul li:not(.hidden-action)');
+			const appListWidth = 179;
+			const checkWidth = Math.ceil(this.$el.find('.column-selection').outerWidth());
+			const headerNameWidth = Math.ceil(this.$el.find('.column-name').outerWidth());
+			const actionWidth = Math.ceil(this.$el.find('#selectedActionLabel').outerWidth());
+			const allLabelWidth = Math.ceil(this.$el.find('#allLabel').not('#allLabel:hidden').outerWidth());
+			let headerWidth = Math.ceil(this.$el.find('.files-filestable thead').outerWidth());
+
+			if($('#app-sidebar-vue').length>0){
+				headerWidth = headerWidth - Math.ceil($('#app-sidebar-vue').outerWidth());
+			}
+
+			var availableWidth;
+			if(!allLabelWidth){
+				availableWidth = headerWidth - (checkWidth + headerNameWidth);
+			}
+			else{
+				availableWidth = headerWidth - (checkWidth + allLabelWidth+ headerNameWidth);
+			}
+
+			let appCount = Math.floor((availableWidth / appListWidth));
+
+			if(appCount < appList.length) {
+
+				if(!allLabelWidth){
+					availableWidth = headerWidth - (checkWidth + headerNameWidth + actionWidth);
+				}
+				else{
+					availableWidth = headerWidth - (checkWidth + allLabelWidth+ headerNameWidth + actionWidth);
+				}
+					appCount = Math.floor((availableWidth / appListWidth));
+			}
+
+			var summary = this._selectionSummary.summary;
+			if (summary.totalFiles === 0 && summary.totalDirs === 0) {
+				this.$el.find('#selectedActionLabel').css('display','none');
+			}
+			else{
+				if(appCount < appList.length) {
+					this.$el.find('#selectedActionLabel').css('display','block');
+				}
+				else if(appCount == appList.length){
+					this.$el.find('#selectedActionLabel').css('display','none');
+				}
+				else if (!isFinite(appCount))
+				{
+					this.$el.find('#selectedActionLabel').css('display','block');
+				}
+				else if(appCount > appList.length){
+					this.$el.find('#selectedActionLabel').css('display','none');
+				}
+			}
+
+			for (let k = 0; k < appList.length; k++) {
+				if (k < appCount) {
+					$(appList[k]).removeClass('hidden');
+				} else {
+					$(appList[k]).addClass('hidden');
 				}
 			}
 		},

--- a/apps/files/js/filemultipleselectionmenu.js
+++ b/apps/files/js/filemultipleselectionmenu.js
@@ -9,9 +9,9 @@
  */
 
 (function() {
-	var FileMultiSelectMenu = OC.Backbone.View.extend({
+	var FileMultipleSelectionMenu = OC.Backbone.View.extend({
 		tagName: 'div',
-		className: 'filesSelectMenu popovermenu bubble menu-right',
+		className: 'filesSelectionMenu',
 		_scopes: null,
 		initialize: function(menuItems) {
 			this._scopes = menuItems;
@@ -34,17 +34,16 @@
 		 * @param {OCA.Files.FileActionContext} context context
 		 * @param {Object} $trigger trigger element
 		 */
-		show: function(context) {
+		 show: function(context) {
 			this._context = context;
-			this.$el.removeClass('hidden');
-			OC.showMenu(null, this.$el);
 			return false;
 		},
 		toggleItemVisibility: function (itemName, show) {
+			var toggle= $('.filesSelectionMenu');
 			if (show) {
-				this.$el.find('.item-' + itemName).removeClass('hidden');
+				toggle.find('.item-' + itemName).removeClass('hidden-action');
 			} else {
-				this.$el.find('.item-' + itemName).addClass('hidden');
+				toggle.find('.item-' + itemName).addClass('hidden-action');
 			}
 		},
 		updateItemText: function (itemName, translation) {
@@ -88,5 +87,5 @@
 		}
 	});
 
-	OCA.Files.FileMultiSelectMenu = FileMultiSelectMenu;
+	OCA.Files.FileMultipleSelectionMenu = FileMultipleSelectionMenu;
 })(OC, OCA);


### PR DESCRIPTION
This PR contains the following changes:
File action button behaviour changes:

We now show more single actions depending on the viewport size in the table header beginning from the first option in the dropdown.
We add a new option called "Cancel" (ger: Abbrechen") which will remove any selection (just remove selection, not the files of course).
We right align the Actions button.
We will show every option in the action button dropdown. It doesnt matter which option is also shown in the table header.
We add a new label called "All".
on S: we hide the label "All" according to the screen design

Dependency for this PR:- 
Theme PR:- https://github.com/nextmcloud/nmc_custom_theming/pull/13