### PR TITLE
[backport]Add button folder and text document creation

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1936,7 +1936,7 @@
 			}
 
 			if (options.scrollTo) {
-				this.scrollTo(fileData.name);
+				this.scrollTo(fileData.name, options.showDetailsView !== undefined ? options.showDetailsView : true);
 			}
 
 			// defaults to true if not defined
@@ -3071,7 +3071,7 @@
 		 *
 		 * @since 8.2
 		 */
-		createDirectory: function(name) {
+		createDirectory: function(name, options) {
 			var self = this;
 			var deferred = $.Deferred();
 			var promise = deferred.promise();
@@ -3087,7 +3087,8 @@
 
 			this.filesClient.createDirectory(targetPath)
 				.done(function() {
-					self.addAndFetchFileInfo(targetPath, '', {scrollTo:true}).then(function(status, data) {
+					options = _.extend({scrollTo: true}, options || {});
+					self.addAndFetchFileInfo(targetPath, '', options).then(function(status, data) {
 						deferred.resolve(status, data);
 					}, function() {
 						OC.Notification.show(t('files', 'Could not create folder "{dir}"',
@@ -3098,8 +3099,9 @@
 				.fail(function(createStatus) {
 					// method not allowed, folder might exist already
 					if (createStatus === 405) {
+						options = _.extend({scrollTo: true}, options || {});
 						// add it to the list, for completeness
-						self.addAndFetchFileInfo(targetPath, '', {scrollTo:true})
+						self.addAndFetchFileInfo(targetPath, '', options)
 							.done(function(status, data) {
 								OC.Notification.show(t('files', 'Could not create folder "{dir}" because it already exists',
 									{dir: name}), {type: 'error'}
@@ -3337,11 +3339,11 @@
 			this.$el.find('.mask').remove();
 			this.$table.removeClass('hidden');
 		},
-		scrollTo:function(file) {
+		scrollTo:function(file, showDetailsView = true) {
 			if (!_.isArray(file)) {
 				file = [file];
 			}
-			if (file.length === 1) {
+			if (file.length === 1 && showDetailsView) {
 				_.defer(function() {
 					if (document.documentElement.clientWidth > 1024) {
 						this.showDetailsView(file[0]);
@@ -3559,7 +3561,11 @@
 		},
 
 		getUniqueName: function(name) {
-			if (this.findFileEl(name).exists()) {
+			var fileNamesOld = this.files.findIndex(function(el)
+			{
+				return el.name==name;
+			});
+			if (fileNamesOld!=-1) {
 				var numMatch;
 				var parts=name.split('.');
 				var extension = "";

--- a/apps/files/js/newfilemenu.js
+++ b/apps/files/js/newfilemenu.js
@@ -52,7 +52,11 @@
 				iconClass: 'icon-folder',
 				fileType: 'folder',
 				actionHandler: function(name) {
-					self.fileList.createDirectory(name);
+					const uniqueName = self.fileList.getUniqueName(name)
+					let tempPromise = self.fileList.createDirectory(uniqueName, { showDetailsView: false })
+					Promise.all([tempPromise]).then(() => {
+						self.fileList.rename(uniqueName)
+					})
 				}
 		        }];
 
@@ -90,100 +94,13 @@
 
 		_promptFileName: function($target) {
 			var self = this;
-
-			if ($target.find('form').length) {
-				$target.find('input[type=\'text\']').focus();
-				return;
-			}
-
-			// discard other forms
-			this.$el.find('form').remove();
-			this.$el.find('.displayname').removeClass('hidden');
-
-			$target.find('.displayname').addClass('hidden');
-
-			var newName = $target.attr('data-templatename');
-			var fileType = $target.attr('data-filetype');
-			var $form = $(OCA.Files.Templates['newfilemenu_filename_form']({
-				fileName: newName,
-				cid: this.cid,
-				fileType: fileType
-			}));
-
-			//this.trigger('actionPerformed', action);
-			$target.append($form);
-
-			// here comes the OLD code
-			var $input = $form.find('input[type=\'text\']');
-			var $submit = $form.find('input[type=\'submit\']');
-
-			var lastPos;
-			var checkInput = function () {
-				// Special handling for the setup template directory
-				if ($target.attr('data-action') === 'template-init') {
-					return true;
-				}
-
-				var filename = $input.val();
-				try {
-					if (!Files.isFileNameValid(filename)) {
-						// Files.isFileNameValid(filename) throws an exception itself
-					} else if (self.fileList.inList(filename)) {
-						throw t('files', '{newName} already exists', {newName: filename}, undefined, {
-							escape: false
-						});
-					} else {
-						return true;
-					}
-				} catch (error) {
-					$input.attr('title', error);
-					$input.addClass('error');
-				}
-				return false;
-			};
-
-			// verify filename on typing
-			$input.keyup(function() {
-				if (checkInput()) {
-					$input.removeClass('error');
-				}
-			});
-
-			$submit.click(function(event) {
-				event.stopPropagation();
-				event.preventDefault();
-				$form.submit();
-			});
-
-			$input.focus();
-			// pre select name up to the extension
-			lastPos = newName.lastIndexOf('.');
-			if (lastPos === -1) {
-				lastPos = newName.length;
-			}
-			$input.selectRange(0, lastPos);
-
-			$form.submit(function(event) {
-				event.stopPropagation();
-				event.preventDefault();
-
-				if (checkInput()) {
-					var newname = $input.val().trim();
-
-					/* Find the right actionHandler that should be called.
-					 * Actions is retrieved by using `actionSpec.id` */
-					var action = _.filter(self._menuItems, function(item) {
-						return item.id == $target.attr('data-action');
-					}).pop();
-					action.actionHandler(newname);
-
-					$form.remove();
-					$target.find('.displayname').removeClass('hidden');
-					OC.hideMenus();
-				}
-			});
+			var newname = $target.attr('data-templatename');
+			var action = _.filter(self._menuItems, function(item) {
+				return item.id == $target.attr('data-action');
+			}).pop();
+			action.actionHandler(newname);
+			OC.hideMenus();
 		},
-
 		/**
 		* Add a new item menu entry in the “New” file menu (in
 		* last position). By clicking on the item, the

--- a/apps/files/src/templates.js
+++ b/apps/files/src/templates.js
@@ -110,7 +110,8 @@ templates.forEach((provider, index) => {
 				iconClass: provider.iconClass || 'icon-file',
 				fileType: 'file',
 				actionHandler(name) {
-					TemplatePicker.open(name, provider)
+					const fileName = FileList.getUniqueName(name)
+					TemplatePicker.open(fileName, provider)
 				},
 			})
 		},

--- a/apps/files/src/views/TemplatePicker.vue
+++ b/apps/files/src/views/TemplatePicker.vue
@@ -64,13 +64,14 @@
 </template>
 
 <script>
-import { normalize } from 'path'
 import { showError } from '@nextcloud/dialogs'
+import { generateOcsUrl } from '@nextcloud/router'
+import axios from '@nextcloud/axios'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent'
 import NcModal from '@nextcloud/vue/dist/Components/NcModal'
 
 import { getCurrentDirectory } from '../utils/davUtils'
-import { createFromTemplate, getTemplates } from '../services/Templates'
+import { getTemplates } from '../services/Templates'
 import TemplatePreview from '../components/TemplatePreview'
 
 const border = 2
@@ -201,37 +202,18 @@ export default {
 			const currentDirectory = getCurrentDirectory()
 			const fileList = OCA?.Files?.App?.currentFileList
 
-			// If the file doesn't have an extension, add the default one
-			if (this.nameWithoutExt === this.name) {
-				this.logger.debug('Fixed invalid filename', { name: this.name, extension: this.provider?.extension })
-				this.name = this.name + this.provider?.extension
-			}
-
 			try {
-				const fileInfo = await createFromTemplate(
-					normalize(`${currentDirectory}/${this.name}`),
-					this.selectedTemplate?.filename,
-					this.selectedTemplate?.templateType,
-				)
-				this.logger.debug('Created new file', fileInfo)
-
-				// Fetch FileInfo and model
-				const data = await fileList?.addAndFetchFileInfo(this.name).then((status, data) => data)
-				const model = new OCA.Files.FileInfoModel(data, {
-					filesClient: fileList?.filesClient,
+				const response = await axios.post(generateOcsUrl('apps/files/api/v1/templates/create'), {
+					filePath: `${currentDirectory}/${this.name}`,
+					templatePath: this.selectedTemplate?.filename,
+					templateType: this.selectedTemplate?.templateType,
 				})
 
-				// Run default action
-				const fileAction = OCA.Files.fileActions.getDefaultFileAction(fileInfo.mime, 'file', OC.PERMISSION_ALL)
-				if (fileAction) {
-					fileAction.action(fileInfo.basename, {
-						$file: fileList?.findFileEl(this.name),
-						dir: currentDirectory,
-						fileList,
-						fileActions: fileList?.fileActions,
-						fileInfoModel: model,
-					})
-				}
+				const fileInfo = response.data.ocs.data
+				this.logger.debug('Created new file', fileInfo)
+				const options = _.extend({ scrollTo: true }, { showDetailsView: false } || {})
+				await fileList?.addAndFetchFileInfo(this.name, undefined, options)
+				fileList.rename(this.name)
 
 				this.close()
 			} catch (error) {


### PR DESCRIPTION
**This PR contains the following changes:**
Add button folder creation changes:

Removed the functionality to enter a name to an added folder
Changed the function to add a folder: the folder will be created called "New folder" or "Neuer Ordner" with an activated rename function
if a folder called "Neuer Ordner" or "New folder" already exists, the created folder will have a counter like "New folder (2)"

Add button text document creation changes:

Removed the functionality to enter a name to an added text document
The document will be created called "New text document" or "Neues Textdokument" with an activated rename function
If a text document is exisitng and already called "New text document" or "Neues Textdokument", the created document will have a counter like "New text document (2)"