### PR TITLE
NC Patch - Adding disable authtoken functionality to release 25

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -353,6 +353,16 @@ $CONFIG = [
 'auth.bruteforce.protection.enabled' => true,
 
 /**
+ * Whether the authtoken v1 provider should be skipped
+ *
+ * The v1 provider is deprecated and removed in Nextcloud 24 onwards. It can be
+ * disabled already when the instance was installed after Nextcloud 14.
+ *
+ * Defaults to ``false``
+ */
+'auth.authtoken.v1.disabled' => false,
+
+/**
  * Whether the rate limit protection shipped with Nextcloud should be enabled or not.
  *
  * Disabling this is discouraged for security reasons.

--- a/lib/private/Authentication/Token/PublicKeyTokenMapper.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenMapper.php
@@ -31,12 +31,18 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use OCP\IConfig;
 
 /**
  * @template-extends QBMapper<PublicKeyToken>
  */
 class PublicKeyTokenMapper extends QBMapper {
-	public function __construct(IDBConnection $db) {
+
+	/** @var IConfig */
+	protected $config;
+
+	public function __construct(IDBConnection $db, IConfig $config) {
+		$this->config = $config;
 		parent::__construct($db, 'authtoken');
 	}
 
@@ -46,6 +52,10 @@ class PublicKeyTokenMapper extends QBMapper {
 	 * @param string $token
 	 */
 	public function invalidate(string $token) {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			return;
+		}
+
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
@@ -75,6 +85,10 @@ class PublicKeyTokenMapper extends QBMapper {
 	 * @throws DoesNotExistException
 	 */
 	public function getToken(string $token): PublicKeyToken {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			throw new DoesNotExistException('Authtoken v1 disabled');
+		}
+
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 		$result = $qb->select('*')
@@ -97,6 +111,10 @@ class PublicKeyTokenMapper extends QBMapper {
 	 * @throws DoesNotExistException
 	 */
 	public function getTokenById(int $id): PublicKeyToken {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			throw new DoesNotExistException('Authtoken v1 disabled');
+		}
+
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 		$result = $qb->select('*')
@@ -123,6 +141,10 @@ class PublicKeyTokenMapper extends QBMapper {
 	 * @return PublicKeyToken[]
 	 */
 	public function getTokenByUser(string $uid): array {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			return [];
+		}
+
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
@@ -142,6 +164,10 @@ class PublicKeyTokenMapper extends QBMapper {
 	}
 
 	public function deleteById(string $uid, int $id) {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			return;
+		}
+
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
@@ -157,6 +183,10 @@ class PublicKeyTokenMapper extends QBMapper {
 	 * @param string $name
 	 */
 	public function deleteByName(string $name) {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			return;
+		}
+
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
 			->where($qb->expr()->eq('name', $qb->createNamedParameter($name), IQueryBuilder::PARAM_STR))

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -100,6 +100,10 @@ class PublicKeyTokenProvider implements IProvider {
 								  string $name,
 								  int $type = IToken::TEMPORARY_TOKEN,
 								  int $remember = IToken::DO_NOT_REMEMBER): IToken {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			throw new InvalidTokenException('Authtokens v1 disabled');
+		}
+
 		if (strlen($token) < self::TOKEN_MIN_LENGTH) {
 			$exception = new InvalidTokenException('Token is too short, minimum of ' . self::TOKEN_MIN_LENGTH . ' characters is required, ' . strlen($token) . ' characters given');
 			$this->logger->error('Invalid token provided when generating new token', ['exception' => $exception]);
@@ -134,6 +138,10 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	public function getToken(string $tokenId): IToken {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			throw new InvalidTokenException('Authtokens v1 disabled');
+		}
+
 		/**
 		 * Token length: 72
 		 * @see \OC\Core\Controller\ClientFlowLoginController::generateAppPassword
@@ -196,6 +204,10 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	public function getTokenById(int $tokenId): IToken {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			throw new InvalidTokenException('Authtokens v1 disabled');
+		}
+
 		try {
 			$token = $this->mapper->getTokenById($tokenId);
 		} catch (DoesNotExistException $ex) {
@@ -219,6 +231,10 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	public function renewSessionToken(string $oldSessionId, string $sessionId): IToken {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			throw new InvalidTokenException('Authtokens v1 disabled');
+		}
+
 		$this->cache->clear();
 
 		return $this->atomic(function () use ($oldSessionId, $sessionId) {
@@ -250,6 +266,10 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	public function invalidateToken(string $token) {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			return;
+		}
+
 		$this->cache->clear();
 
 		$this->mapper->invalidate($this->hashToken($token));
@@ -257,12 +277,20 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	public function invalidateTokenById(string $uid, int $id) {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			return;
+		}
+
 		$this->cache->clear();
 
 		$this->mapper->deleteById($uid, $id);
 	}
 
 	public function invalidateOldTokens() {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			return;
+		}
+
 		$this->cache->clear();
 
 		$olderThan = $this->time->getTime() - $this->config->getSystemValueInt('session_lifetime', 60 * 60 * 24);
@@ -274,6 +302,10 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	public function updateToken(IToken $token) {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			throw new InvalidTokenException('Authtokens v1 disabled');
+		}
+
 		$this->cache->clear();
 
 		if (!($token instanceof PublicKeyToken)) {
@@ -283,6 +315,10 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	public function updateTokenActivity(IToken $token) {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			throw new InvalidTokenException('Authtokens v1 disabled');
+		}
+
 		$this->cache->clear();
 
 		if (!($token instanceof PublicKeyToken)) {
@@ -301,6 +337,10 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	public function getTokenByUser(string $uid): array {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			return [];
+		}
+
 		return $this->mapper->getTokenByUser($uid);
 	}
 
@@ -321,6 +361,10 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	public function setPassword(IToken $token, string $tokenId, string $password) {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			throw new InvalidTokenException('Authtokens v1 disabled');
+		}
+
 		$this->cache->clear();
 
 		if (!($token instanceof PublicKeyToken)) {
@@ -348,6 +392,10 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	public function rotate(IToken $token, string $oldTokenId, string $newTokenId): IToken {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			throw new InvalidTokenException('Authtokens v1 disabled');
+		}
+
 		$this->cache->clear();
 
 		if (!($token instanceof PublicKeyToken)) {
@@ -473,6 +521,10 @@ class PublicKeyTokenProvider implements IProvider {
 	}
 
 	public function markPasswordInvalid(IToken $token, string $tokenId) {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			throw new InvalidTokenException('Authtokens v1 disabled');
+		}
+		
 		$this->cache->clear();
 
 		if (!($token instanceof PublicKeyToken)) {

--- a/lib/private/Authentication/Token/TokenCleanupJob.php
+++ b/lib/private/Authentication/Token/TokenCleanupJob.php
@@ -23,19 +23,30 @@ namespace OC\Authentication\Token;
 
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\IConfig;
 
 class TokenCleanupJob extends TimedJob {
+	
+	/**
+	 *  @var IConfig 
+	 * */
+	protected $config;
 	private IProvider $provider;
 
-	public function __construct(ITimeFactory $time, IProvider $provider) {
+	public function __construct(ITimeFactory $time, IProvider $provider, IConfig $config) {
 		parent::__construct($time);
 		$this->provider = $provider;
 		// Run once a day at off-peak time
 		$this->setInterval(24 * 60 * 60);
 		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+		$this->config = $config;
 	}
 
 	protected function run($argument) {
+		if ($this->config->getSystemValueBool('auth.authtoken.v1.disabled')) {
+			return;
+		}
+		
 		$this->provider->invalidateOldTokens();
 	}
 }

--- a/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
@@ -32,6 +32,8 @@ use OC\Authentication\Token\PublicKeyTokenMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IUser;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 /**
@@ -44,6 +46,9 @@ class PublicKeyTokenMapperTest extends TestCase {
 	/** @var IDBConnection */
 	private $dbConnection;
 
+	/** @var IConfig|MockObject */
+	private $config;
+
 	/** @var int */
 	private $time;
 
@@ -52,9 +57,10 @@ class PublicKeyTokenMapperTest extends TestCase {
 
 		$this->dbConnection = OC::$server->getDatabaseConnection();
 		$this->time = time();
+		$this->config = $this->createMock(IConfig::class);
 		$this->resetDatabase();
 
-		$this->mapper = new PublicKeyTokenMapper($this->dbConnection);
+		$this->mapper = new PublicKeyTokenMapper($this->dbConnection, $this->config);
 	}
 
 	private function resetDatabase() {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

NC Patch to Adding disable authtoken functionality on config file and access config variables on Token accessed files and testcases


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
