### PR TITLE
add store.js file for state management for current tab and include sh…

### DIFF
--- a/apps/files_sharing/src/files_sharing_tab.js
+++ b/apps/files_sharing/src/files_sharing_tab.js
@@ -29,7 +29,7 @@ import ShareSearch from './services/ShareSearch.js'
 import ExternalLinkActions from './services/ExternalLinkActions.js'
 import ExternalShareActions from './services/ExternalShareActions.js'
 import TabSections from './services/TabSections.js'
-
+import store from './store'
 // eslint-disable-next-line n/no-missing-import, import/no-unresolved
 import ShareVariant from '@mdi/svg/svg/share-variant.svg?raw'
 
@@ -59,25 +59,31 @@ window.addEventListener('DOMContentLoaded', function() {
 			iconSvg: ShareVariant,
 
 			async mount(el, fileInfo, context) {
-				const SharingTab = (await import('./views/SharingTab.vue')).default
-				const View = Vue.extend(SharingTab)
+				//const SharingTab = (await import('./views/SharingTab.vue')).default
+				const SharingTabCustom = (await import('./../../../themes/magentacloud25/custom/apps/files_sharing/src/views/SharingTab.vue')).default
+				const View = Vue.extend(SharingTabCustom)
 
 				if (TabInstance) {
 					TabInstance.$destroy()
+					
 				}
 				TabInstance = new View({
 					// Better integration with vue parent component
 					parent: context,
+					store
 				})
 				// Only mount after we have all the info we need
 				await TabInstance.update(fileInfo)
 				TabInstance.$mount(el)
+				OCA.Files.Sidebar.setActiveTab('sharing')
 			},
 			update(fileInfo) {
 				TabInstance.update(fileInfo)
+				store.commit('addCurrentTab', 'default')
 			},
 			destroy() {
 				TabInstance.$destroy()
+				store.commit('addCurrentTab', 'default')
 				TabInstance = null
 			},
 		}))

--- a/apps/files_sharing/src/store.js
+++ b/apps/files_sharing/src/store.js
@@ -1,0 +1,78 @@
+/**
+ * @copyright Copyright (c) 2021 Yogesh Shejwadkar <yogesh.shejwadkar@t-systems.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import Vue from 'vue'
+import Vuex from 'vuex'
+import Share from './models/Share'
+
+Vue.use(Vuex)
+
+const store = new Vuex.Store({
+	state: {
+		share: {
+			type: Share,
+			default: null,
+		},
+		option: {},
+		fromInput: Boolean,
+		currentTab: 'default',
+	},
+	mutations: {
+		addShare(state, share) {
+			state.share = share
+			console.debug('this is addShare mutation', share)
+		},
+		addOption(state, option) {
+			state.option = option
+			console.debug('this is addOptions mutation', option)
+		},
+		addFromInput(state, fromInput) {
+			state.fromInput = fromInput
+			console.debug('this is addFromInput mutation', fromInput)
+		},
+		addCurrentTab(state, currentTab) {
+			state.currentTab = currentTab
+			console.debug('this is addCurrentTab mutation', currentTab)
+		},
+	},
+	actions: {
+
+	},
+	getters: {
+		getShare(state) {
+			console.debug('this is getter getShare', state.share)
+			return state.share
+		},
+		getOption(state) {
+			console.debug('this is getter getOption', state.option)
+			return state.option
+		},
+		getFromInput(state) {
+			console.debug('this is getter getFromInput', state.fromInput)
+			return state.fromInput
+		},
+		getCurrentTab(state) {
+			console.debug('this is getter getCurrentTab', state.currentTab)
+			return state.currentTab
+		},
+	},
+})
+
+export default store


### PR DESCRIPTION
add store.js file for state management for the current tab and include sharingTab.vue from themes after refactoring and inheritance

1. Remove the old code and shifted to the new location
2. Apply Inheritance to use parent properties
3. remove the magenta-related css from the vue files. 

Made changes in source code also to create an instance of sharing tab  
 
Theme repo related branch
[https://github.com/nextmcloud/nmc_custom_theming/pull/41](https://github.com/nextmcloud/nmc_custom_theming/pull/41)
 

 