### PR TITLE
[backport25] No session on day API call

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -158,6 +158,7 @@ class ViewController extends Controller {
 	/**
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
+     * @UseSession
 	 *
 	 * @param string $fileid
 	 * @return TemplateResponse|RedirectResponse

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -42,6 +42,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\ISession;
 use OCP\IUser;
+use OCP\Session\Exceptions\SessionNotAvailableException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -362,7 +363,7 @@ class Manager {
 					$this->session->set(self::SESSION_UID_DONE, $user->getUID());
 					return false;
 				}
-			} catch (InvalidTokenException $e) {
+			} catch (InvalidTokenException|SessionNotAvailableException $e) {
 			}
 		}
 


### PR DESCRIPTION
Nextcloud still creates a new session on each API call.
This will flood MagentaCLOUD Redis setup, esp. due to frequent API calls from Magenta HomeOS to store
observation cam movie files.

There is no unambiguous identification found for API calls yet, so that https://github.com/nextcloud/server/pull/28311 is disabled
to date (stable27).

The backport is required to add parts of the patch that are already included in later versions (ViewController.php, Manager.php)

## Checklist

- [ ] REDIS load test