### PR TITLE
Fix mimetype for binary files migrated as application/octet-stream

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -556,6 +556,15 @@ class File extends Node implements IFile {
 	public function getContentType() {
 		$mimeType = $this->info->getMimetype();
 
+		if ($mimeType === 'application/octet-stream') {
+			$mimeType = \OC::$server->getMimeTypeDetector()->detectPath($this->info->getInternalPath());
+			if ($this->info->getMimetype() !== $mimeType) {
+				$this->info->getStorage()->getCache()->update($this->info->getId(), [
+					'mimetype' => $mimeType
+				]);
+			}
+		}
+
 		// PROPFIND needs to return the correct mime type, for consistency with the web UI
 		if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'PROPFIND') {
 			return $mimeType;


### PR DESCRIPTION
The mime type is recomputed on dev file access in MagentaCLOUD only for files with `application/octet-stream` mimetype.
The reason is a bug in migration that is fixed "lazy" with adding the recompilation and has to be kept
infinitely.
