### PR TITLE
[backport 27]Multiple cron background jobs based on class - Patch - maybe need a new for nc28

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -142,7 +142,8 @@ try {
 		$endTime = time() + 14 * 60;
 
 		$executedJobs = [];
-		while ($job = $jobList->getNext($onlyTimeSensitive)) {
+		$jobClass = isset($argv[1]) ? $argv[1] : null;
+		while ($job = $jobList->getNext($onlyTimeSensitive, $jobClass)) {
 			if (isset($executedJobs[$job->getId()])) {
 				$jobList->unlockJob($job);
 				break;

--- a/tests/lib/BackgroundJob/DummyJobList.php
+++ b/tests/lib/BackgroundJob/DummyJobList.php
@@ -96,7 +96,7 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 	/**
 	 * get the next job in the list
 	 */
-	public function getNext(bool $onlyTimeSensitive = false): ?IJob {
+	public function getNext(bool $onlyTimeSensitive = false, string $jobClass = null): ?IJob {
 		if (count($this->jobs) > 0) {
 			if ($this->last < (count($this->jobs) - 1)) {
 				$i = $this->last + 1;


### PR DESCRIPTION
…julius.haertl@nextcloud.com>


* Resolves: Multiple cron background jobs based on class

## Summary
Hi,

As discussed in the call earlier this week, I prepared an adjusted version of the patch to run a background job just for a specific class.

This is slightly different from the upstream PR to only include minimal changes as they used to be on your nextcloud 25 deployment. I’ll try to push finishing the actual upstream change forward for the 29 branch, but would recommend to stick to the simple patch variant for now.

I was not sure if I should just push it to the branch in https://github.com/nextmcloud/server/pull/245, so for now only attached as a single commit patch file.

Let me know if you have any questions.

Best regards,
Julius
