### PR TITLE
[backport 27]fix: Avoid clear cache with prefix [maybe needed for 28]

### DIFF
--- a/lib/private/Collaboration/Reference/ReferenceManager.php
+++ b/lib/private/Collaboration/Reference/ReferenceManager.php
@@ -137,6 +137,11 @@ class ReferenceManager implements IReferenceManager {
 
 		$reference = $matchedProvider->resolveReference($referenceId);
 		if ($reference) {
+			$cachePrefix = $matchedProvider->getCachePrefix($referenceId);
+			if ($cachePrefix !== '') {
+				// If a prefix is used we set an additional key to know when we need to delete by prefix during invalidateCache()
+				$this->cache->set('hasPrefix-' . md5($cachePrefix), true, self::CACHE_TTL);
+			}
 			$this->cache->set($cacheKey, Reference::toCache($reference), self::CACHE_TTL);
 			return $reference;
 		}
@@ -190,11 +195,15 @@ class ReferenceManager implements IReferenceManager {
 	 */
 	public function invalidateCache(string $cachePrefix, ?string $cacheKey = null): void {
 		if ($cacheKey === null) {
-			$this->cache->clear(md5($cachePrefix));
+			// clear might be a heavy operation, so we only do it if there have actually been keys set
+			if ($this->cache->remove('hasPrefix-' . md5($cachePrefix))) {
+				$this->cache->clear(md5($cachePrefix));
+			}
+
 			return;
 		}
 
-		$this->cache->remove(md5($cachePrefix) . '-' . md5($cacheKey));
+		$this->cache->remove(md5($cachePrefix) . '-' . md5($cacheKey ?? ''));
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary
https://github.com/nextcloud/server/pull/43992/files

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
