### PR TITLE
[backport27] Unencrypted size patch - for database optimization

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -119,7 +119,7 @@ class Updater implements IUpdater {
 	 * @param string $path
 	 * @param int $time
 	 */
-	public function update($path, $time = null) {
+	public function update($path, $time = null, ?int $sizeDifference = null) {
 		if (!$this->enabled or Scanner::isPartialFile($path)) {
 			return;
 		}
@@ -128,20 +128,22 @@ class Updater implements IUpdater {
 		}
 
 		$data = $this->scanner->scan($path, Scanner::SCAN_SHALLOW, -1, false);
-		if (
-			isset($data['oldSize']) && isset($data['size']) &&
-			!$data['encrypted'] // encryption is a pita and touches the cache itself
-		) {
+
+		if (isset($data['oldSize']) && isset($data['size'])) {
 			$sizeDifference = $data['size'] - $data['oldSize'];
-		} else {
-			// scanner didn't provide size info, fallback to full size calculation
-			$sizeDifference = 0;
-			if ($this->cache instanceof Cache) {
-				$this->cache->correctFolderSize($path, $data);
-			}
+		}
+
+		// encryption is a pita and touches the cache itself
+		if (isset($data['encrypted']) && !!$data['encrypted']) {
+			$sizeDifference = null;
+		}
+
+		// scanner didn't provide size info, fallback to full size calculation
+		if ($this->cache instanceof Cache && $sizeDifference === null) {
+			$this->cache->correctFolderSize($path, $data);
 		}
 		$this->correctParentStorageMtime($path);
-		$this->propagator->propagateChange($path, $time, $sizeDifference);
+		$this->propagator->propagateChange($path, $time, $sizeDifference ?? 0);
 	}
 
 	/**

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -287,12 +287,12 @@ class View {
 		$this->updaterEnabled = true;
 	}
 
-	protected function writeUpdate(Storage $storage, string $internalPath, ?int $time = null): void {
+	protected function writeUpdate(Storage $storage, string $internalPath, ?int $time = null, ?int $sizeDifference = null): void {
 		if ($this->updaterEnabled) {
 			if (is_null($time)) {
 				$time = time();
 			}
-			$storage->getUpdater()->update($internalPath, $time);
+			$storage->getUpdater()->update($internalPath, $time, $sizeDifference);
 		}
 	}
 
@@ -1173,7 +1173,9 @@ class View {
 					$this->removeUpdate($storage, $internalPath);
 				}
 				if ($result !== false && in_array('write', $hooks, true) && $operation !== 'fopen' && $operation !== 'touch') {
-					$this->writeUpdate($storage, $internalPath);
+					$isCreateOperation = $operation === 'mkdir' || ($operation === 'file_put_contents' && in_array('create', $hooks, true));
+					$sizeDifference = $operation === 'mkdir' ? 0 : $result;
+					$this->writeUpdate($storage, $internalPath, null, $isCreateOperation ? $sizeDifference : null);
 				}
 				if ($result !== false && in_array('touch', $hooks)) {
 					$this->writeUpdate($storage, $internalPath, $extraParam);

--- a/lib/public/Files/Cache/IUpdater.php
+++ b/lib/public/Files/Cache/IUpdater.php
@@ -53,7 +53,7 @@ interface IUpdater {
 	 * @param int $time
 	 * @since 9.0.0
 	 */
-	public function update($path, $time = null);
+	public function update($path, $time = null, ?int $sizeDifference = null);
 
 	/**
 	 * Remove $path from the cache and update the size, etag and mtime of the parent folders


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary
Unencrypted size patch - for database optimization. We need to ask NC for v28 patch when we deployong v28!
https://github.com/nextcloud/server/commit/859636303331add685466858074fb4f7494f53cf

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
