### PR TITLE
[backport 28]Revert NC change to be able to authenticate with email address - webd…

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -438,15 +438,8 @@ class Session implements IUserSession, Emitter {
 				return false;
 			}
 
-			if ($isTokenPassword) {
-				$dbToken = $this->tokenProvider->getToken($password);
-				$userFromToken = $this->manager->get($dbToken->getUID());
-				$isValidEmailLogin = $userFromToken->getEMailAddress() === $user
-					&& $this->validateTokenLoginName($userFromToken->getEMailAddress(), $dbToken);
-			} else {
 				$users = $this->manager->getByEmail($user);
 				$isValidEmailLogin = (\count($users) === 1 && $this->login($users[0]->getUID(), $password));
-			}
 
 			if (!$isValidEmailLogin) {
 				$this->handleLoginFailed($throttler, $currentDelay, $remoteAddress, $user, $password);


### PR DESCRIPTION
Revert NC change to be able to authenticate with email address - webdav clients

(cherry picked from commit 437ad79ba190d126db701a6628977f333689749a)

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
