### PR TITLE
[FIX NC30] Make getL10nFilesForApp() method public to support custom L10N in nmctheme

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -509,7 +509,7 @@ class Factory implements IFactory {
 	 *
 	 * @return string[]
 	 */
-	private function getL10nFilesForApp(string $app, string $lang): array {
+	public function getL10nFilesForApp(string $app, string $lang): array {
 		$languageFiles = [];
 
 		$i18nDir = $this->findL10nDir($app);


### PR DESCRIPTION
Problem: Private method OC\L10N\Factory::getL10nFilesForApp() was not accessible from custom app nmctheme, causing a runtime error.

Solution: Changed the method visibility from private to public to allow controlled access from OCA\NMCTheme\L10N\FactoryDecorator.