### PR TITLE
[FIX NC30] resitricted sharing dialog to open when new subfolder created inside …

### DIFF
--- a/apps/files/src/actions/sidebarAction.ts
+++ b/apps/files/src/actions/sidebarAction.ts
@@ -37,7 +37,7 @@ export const action = new FileAction({
 	async exec(node: Node, view: View, dir: string) {
 		try {
 			// Open sidebar and set active tab to sharing by default
-			window.OCA.Files.Sidebar.setActiveTab('sharing')
+			// window.OCA.Files.Sidebar.setActiveTab('sharing')
 			window.OCA.Files.Sidebar.setActiveTab('sharing-manage');
 
 			// TODO: migrate Sidebar to use a Node instead

--- a/apps/files/src/actions/sidebarAction.ts
+++ b/apps/files/src/actions/sidebarAction.ts
@@ -38,6 +38,7 @@ export const action = new FileAction({
 		try {
 			// Open sidebar and set active tab to sharing by default
 			window.OCA.Files.Sidebar.setActiveTab('sharing')
+			window.OCA.Files.Sidebar.setActiveTab('sharing-manage');
 
 			// TODO: migrate Sidebar to use a Node instead
 			await window.OCA.Files.Sidebar.open(node.path)


### PR DESCRIPTION
…a new folder

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
