### PR TITLE
[V32] Fix @ rules separation in theming controller

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -408,10 +408,14 @@ class ThemingController extends Controller {
 			// from the rest of the CSS.
 			$customCssWithoutComments = preg_replace('!/\*.*?\*/!s', '', $customCss);
 			$customCssWithoutComments = preg_replace('!//.*!', '', $customCssWithoutComments);
+
+			// Extract @import rules, because they MUST appear at the very top of the final CSS
+			// If they remain inside the theme scope or behind normal rules, browsers will ignore them
 			preg_match_all('/(@import[^;]+;)/', $customCssWithoutComments, $imports);
 			$importsCss = implode('', $imports[0]);
 			$customCssWithoutImports = preg_replace('/(@import[^;]+;)/', '', $customCssWithoutComments);
 
+			// Extract all remaining @-rules (e.g. @media), because they cannot be nested inside the theme scope
 			preg_match_all('/(@[^{]+{(?:[^{}]*|(?R))*})/', $customCssWithoutImports, $atRules);
 			$atRulesCss = implode('', $atRules[0]);
 			$scopedCss = preg_replace('/(@[^{]+{(?:[^{}]*|(?R))*})/', '', $customCssWithoutImports);

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -408,11 +408,15 @@ class ThemingController extends Controller {
 			// from the rest of the CSS.
 			$customCssWithoutComments = preg_replace('!/\*.*?\*/!s', '', $customCss);
 			$customCssWithoutComments = preg_replace('!//.*!', '', $customCssWithoutComments);
-			preg_match_all('/(@[^{]+{(?:[^{}]*|(?R))*})/', $customCssWithoutComments, $atRules);
-			$atRulesCss = implode('', $atRules[0]);
-			$scopedCss = preg_replace('/(@[^{]+{(?:[^{}]*|(?R))*})/', '', $customCssWithoutComments);
+			preg_match_all('/(@import[^;]+;)/', $customCssWithoutComments, $imports);
+			$importsCss = implode('', $imports[0]);
+			$customCssWithoutImports = preg_replace('/(@import[^;]+;)/', '', $customCssWithoutComments);
 
-			$css = "$atRulesCss [data-theme-$themeId] { $variables $scopedCss }";
+			preg_match_all('/(@[^{]+{(?:[^{}]*|(?R))*})/', $customCssWithoutImports, $atRules);
+			$atRulesCss = implode('', $atRules[0]);
+			$scopedCss = preg_replace('/(@[^{]+{(?:[^{}]*|(?R))*})/', '', $customCssWithoutImports);
+ 
+            $css = "$importsCss $atRulesCss [data-theme-$themeId] { $variables $scopedCss }";
 		}
 
 		try {


### PR DESCRIPTION
Fixed at-rules separation in theming controller that nextcloud introduced in V31 to replace the SCSS compiler