### PR TITLE
[V33] Hotfix: with sharee enumeration disabled users shall be only searched by email anyways in this environment

### DIFF
--- a/lib/private/Collaboration/Collaborators/UserPlugin.php
+++ b/lib/private/Collaboration/Collaborators/UserPlugin.php
@@ -33,6 +33,16 @@ readonly class UserPlugin implements ISearchPlugin {
 	}
 
 	public function search($search, $limit, $offset, ISearchResult $searchResult): bool {
+		$result = ['wide' => [], 'exact' => []];
+		$users = [];
+		$hasMoreResults = false;
+
+		// Hotfix: with sharee enumeration disabled users shall be only searched by email anyways in this environment,
+		// so for now return just empty results as those are also handled by the MailPlugin
+		$type = new SearchResultType('users');
+		$searchResult->addResultSet($type, $result['wide'], $result['exact']);
+		return false;
+
 		/** @var IUser $currentUser */
 		$currentUser = $this->userSession->getUser();
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
